### PR TITLE
API Integration Testing: Delete a Product

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -17,14 +17,6 @@ from rest_framework.parsers import MultiPartParser, FormParser
 class ProductSerializer(serializers.ModelSerializer):
     """JSON serializer for products"""
 
-    price = serializers.DecimalField(
-        max_digits=7,
-        decimal_places=2,
-        error_messages={
-            "invalid": "Please provide a valid price number between 0 and $17,500.",
-        },
-    )
-
     class Meta:
         model = Product
         fields = (
@@ -46,31 +38,26 @@ class ProductSerializer(serializers.ModelSerializer):
         if value > 17500:
             raise serializers.ValidationError("Price cannot exceed $17,500")
         return value
-    
-    # currently doing for all requests.. should just be on retrieve.
-    # this is causing the all products view to break.
-    # Could we just have different serializers for different methods?
-    # For example, a ProductRetrieveSerializer(ProductSerializer)? profile.py uses multiple serializers.
-    # Then, add the is_liked serializer method field to just that child serializer?
-
 
 
 class ProductDetailSerializer(ProductSerializer):
     is_liked = serializers.SerializerMethodField()
 
     class Meta(ProductSerializer.Meta):
-        fields = ProductSerializer.Meta.fields + ('is_liked',)
+        fields = ProductSerializer.Meta.fields + ("is_liked",)
 
     def get_is_liked(self, obj):
         # Get current request
-        request = self.context.get('request')
-        
+        request = self.context.get("request")
+
         # Use data from the request to find whether the current user likes the current product
         # Get the current user
         current_user = Customer.objects.get(user=request.auth.user)
 
         # Use the related name to check if this product has a like from this customer
-        is_it_liked = ProductLike.objects.filter(customer=current_user,product=obj.pk).exists()
+        is_it_liked = ProductLike.objects.filter(
+            customer=current_user, product=obj.pk
+        ).exists()
         # If they do like the current product, return true
         # If they do not like the current product, return false
 
@@ -388,10 +375,10 @@ class Products(ViewSet):
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @action(methods=["post", "delete"], detail=True)
-    def like(self, request,pk=None):
+    def like(self, request, pk=None):
         current_user = Customer.objects.get(user=request.auth.user)
         product_instance = Product.objects.get(pk=pk)
-        
+
         if request.method == "POST":
             product_like = ProductLike()
             product_like.customer = current_user
@@ -399,24 +386,28 @@ class Products(ViewSet):
 
             product_like.save()
             return Response(None, status=status.HTTP_201_CREATED)
-        
+
         if request.method == "DELETE":
             try:
-                product_like = ProductLike.objects.get(customer=current_user,product=pk)
+                product_like = ProductLike.objects.get(
+                    customer=current_user, product=pk
+                )
                 product_like.delete()
 
                 return Response({}, status=status.HTTP_204_NO_CONTENT)
 
             except ProductLike.DoesNotExist as ex:
-                return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
-            
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
+
             except Exception as ex:
                 return Response(
-                    {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                    {"message": ex.args[0]},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 )
-        
-        return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
+        return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @action(methods=["get"], detail=False)
     def liked(self, request):
@@ -424,13 +415,15 @@ class Products(ViewSet):
 
         if request.method == "GET":
             try:
-                liked_products = Product.objects.filter(product_likes__customer = current_user)
+                liked_products = Product.objects.filter(
+                    product_likes__customer=current_user
+                )
                 json_likes = ProductSerializer(
-                liked_products, many=True, context={'request': request})
+                    liked_products, many=True, context={"request": request}
+                )
                 return Response(json_likes.data, status=status.HTTP_200_OK)
-                 
+
             except Exception as ex:
                 return HttpResponseServerError(ex)
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
-    

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -216,6 +216,9 @@ class Products(ViewSet):
             product = Product.objects.get(pk=pk)
             serializer = ProductDetailSerializer(product, context={"request": request})
             return Response(serializer.data)
+        except Product.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
         except Exception as ex:
             return HttpResponseServerError(ex)
 

--- a/tests/product.py
+++ b/tests/product.py
@@ -10,18 +10,25 @@ class ProductTests(APITestCase):
         Create a new account and create sample category
         """
         url = "/register"
-        data = {"username": "steve", "password": "Admin8*", "email": "steve@stevebrownlee.com",
-                "address": "100 Infinity Way", "phone_number": "555-1212", "first_name": "Steve", "last_name": "Brownlee"}
-        response = self.client.post(url, data, format='json')
+        data = {
+            "username": "steve",
+            "password": "Admin8*",
+            "email": "steve@stevebrownlee.com",
+            "address": "100 Infinity Way",
+            "phone_number": "555-1212",
+            "first_name": "Steve",
+            "last_name": "Brownlee",
+        }
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
         self.token = json_response["token"]
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         url = "/productcategories"
         data = {"name": "Sporting Goods"}
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
 
-        response = self.client.post(url, data, format='json')
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -38,10 +45,10 @@ class ProductTests(APITestCase):
             "quantity": 60,
             "description": "It flies high",
             "category_id": 1,
-            "location": "Pittsburgh"
+            "location": "Pittsburgh",
         }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.post(url, data, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
 
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -65,13 +72,13 @@ class ProductTests(APITestCase):
             "description": "It flies very high",
             "category_id": 1,
             "created_date": datetime.date.today(),
-            "location": "Pittsburgh"
+            "location": "Pittsburgh",
         }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.put(url, data, format='json')
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.put(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        response = self.client.get(url, data, format='json')
+        response = self.client.get(url, data, format="json")
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(json_response["name"], "Kite")
@@ -90,11 +97,35 @@ class ProductTests(APITestCase):
 
         url = "/products"
 
-        response = self.client.get(url, None, format='json')
+        response = self.client.get(url, None, format="json")
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(json_response), 3)
 
     # TODO: Delete product
+
+    def test_delete_a_product(self):
+        """
+        Ensure we can delete a product
+        """
+        # Create 2 Products
+        self.test_create_product()
+        self.test_create_product()
+
+        # Delete first product
+        url = "/products/1"
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get deleted product, make sure it cannot be found.
+        response = self.client.get(url, None, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        # Get list of all products, make sure there is only 1 there.
+        response = self.client.get("/products", None, format="json")
+        json_response = json.loads(response.content)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 1)
 
     # TODO: Product can be rated. Assert average rating exists.

--- a/tests/product.py
+++ b/tests/product.py
@@ -111,6 +111,7 @@ class ProductTests(APITestCase):
         # Create 2 Products
         self.test_create_product()
         self.test_create_product()
+        self.test_create_product()
 
         # Delete first product
         url = "/products/1"
@@ -122,10 +123,10 @@ class ProductTests(APITestCase):
         response = self.client.get(url, None, format="json")
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
-        # Get list of all products, make sure there is only 1 there.
+        # Get list of all products, make sure there are only 2 there.
         response = self.client.get("/products", None, format="json")
         json_response = json.loads(response.content)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(json_response), 1)
+        self.assertEqual(len(json_response), 2)
 
     # TODO: Product can be rated. Assert average rating exists.


### PR DESCRIPTION
# What and Why? 
Fixed provided test suite functioning by modifying the existing Product Serializer, then added an additional API Integration test for deleting a product. 

## How
- ProductSerializer was returning a price string rather than a number. After some research, the serializer decimal field we were using for custom error handling was not returning the expected datatype. Removed the decimal field which solved the issue.
- Created a new test_delete_a_product integration test method in the ProductTests class: 

- This method first creates three test products. 
- Then, it deletes the first product and checks for the appropriate response. 
- Then, it does a get request to the deleted product's url and checks the response code.
- Finally, the test gets the full list of products and checks the response code and the length of the response body against the expected results.

## Testing
NOTE: Since we are using poetry, you have to use `poetry run` prior to the python code. 

First, go to the project directory in your terminal.

Then, 

To run this specific test in verbose mode, run the following code:
`poetry run python manage.py test tests.product.ProductTests.test_delete_a_product -v 2`

To run the full test suite:
`poetry run python manage.py test tests -v 1`



## Related Issues
- Completes ticket #18