### PR TITLE
Test/new line items added

### DIFF
--- a/bangazonapi/fixtures/productlikes.json
+++ b/bangazonapi/fixtures/productlikes.json
@@ -1,0 +1,122 @@
+[
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 1,
+        "fields": {
+            "product": 35,
+            "customer": 5
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 2,
+        "fields": {
+            "product": 12,
+            "customer": 4
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 3,
+        "fields": {
+            "product": 24,
+            "customer": 7
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 4,
+        "fields": {
+            "product": 8,
+            "customer": 6
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 5,
+        "fields": {
+            "product": 42,
+            "customer": 4
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 6,
+        "fields": {
+            "product": 19,
+            "customer": 5
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 7,
+        "fields": {
+            "product": 27,
+            "customer": 6
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 8,
+        "fields": {
+            "product": 35,
+            "customer": 7
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 9,
+        "fields": {
+            "product": 14,
+            "customer": 6
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 10,
+        "fields": {
+            "product": 31,
+            "customer": 5
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 11,
+        "fields": {
+            "product": 22,
+            "customer": 4
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 12,
+        "fields": {
+            "product": 17,
+            "customer": 7
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 13,
+        "fields": {
+            "product": 39,
+            "customer": 5
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 14,
+        "fields": {
+            "product": 5,
+            "customer": 6
+        }
+    },
+    {
+        "model": "bangazonapi.productlike",
+        "pk": 15,
+        "fields": {
+            "product": 29,
+            "customer": 4
+        }
+    }
+]

--- a/bangazonapi/models/__init__.py
+++ b/bangazonapi/models/__init__.py
@@ -8,3 +8,4 @@ from .recommendation import Recommendation
 from .rating import Rating
 from .favorite import Favorite
 from .productrating import ProductRating
+from .productlike import ProductLike

--- a/bangazonapi/models/productlike.py
+++ b/bangazonapi/models/productlike.py
@@ -2,6 +2,5 @@ from  django.db import models
 from .customer import Customer
 
 class ProductLike(models.Model):
-    customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
+    customer = models.ForeignKey(Customer, on_delete=models.CASCADE, related_name="liked_products")
     product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="product_likes")
-

--- a/bangazonapi/models/productlike.py
+++ b/bangazonapi/models/productlike.py
@@ -1,0 +1,7 @@
+from  django.db import models
+from .customer import Customer
+
+class ProductLike(models.Model):
+    customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
+    product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="product_likes")
+

--- a/bangazonapi/models/productlikes.py
+++ b/bangazonapi/models/productlikes.py
@@ -1,0 +1,11 @@
+from  django.db import models
+
+
+
+class ProductLikes(models.Model):
+
+
+
+#     product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="ratings")
+#     customer = models.ForeignKey(Customer, on_delete=models.CASCADE)
+#     rating = models.IntegerField(validators=[MinValueValidator(0), MaxValueValidator(5)])

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -9,3 +9,4 @@ from .productcategory import ProductCategories
 from .lineitem import LineItems
 from .customer import Customers
 from .user import Users
+from .productlike import ProductLike

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -25,6 +25,8 @@ class ProductSerializer(serializers.ModelSerializer):
         },
     )
 
+    is_liked = serializers.SerializerMethodField()
+
     class Meta:
         model = Product
         fields = (
@@ -39,6 +41,7 @@ class ProductSerializer(serializers.ModelSerializer):
             "image_path",
             "average_rating",
             "can_be_rated",
+            "is_liked"
         )
         depth = 1
 
@@ -46,7 +49,21 @@ class ProductSerializer(serializers.ModelSerializer):
         if value > 17500:
             raise serializers.ValidationError("Price cannot exceed $17,500")
         return value
+    
+    def get_is_liked(self, obj):
+        # Get current request
+        request = self.context.get('request')
+        
+        # Use data from the request to find whether the current user likes the current product
+        # Get the current user
+        current_user = Customer.objects.get(user=request.auth.user)
 
+        # Use the related name to check if this product has a like from this customer
+        is_it_liked = ProductLike.objects.filter(customer=current_user,product=obj.pk).exists()
+        # If they do like the current product, return true
+        # If they do not like the current product, return false
+
+        return is_it_liked
 
 class Products(ViewSet):
     """Request handlers for Products in the Bangazon Platform"""

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -357,3 +357,18 @@ class Products(ViewSet):
             return Response(None, status=status.HTTP_204_NO_CONTENT)
 
         return Response(None, status=status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    @action(methods=["get", "post", "delete"], detail=False)
+    def like(self, request):
+        current_user = Customer.objects.get(user=request.auth.user)
+        
+        if request.method == "POST":
+            
+            #Take the product like and compare to existing product likes
+            #if it exists, delete the productlike
+            #if it does not exist, create a new productlike   
+            
+            product_like = ProductLike.objects.filter(customer=current_user, product=request.data["product_id"])
+        
+            return Response(product_like.data)
+        return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -17,13 +17,13 @@ from rest_framework.parsers import MultiPartParser, FormParser
 class ProductSerializer(serializers.ModelSerializer):
     """JSON serializer for products"""
 
-    price = serializers.DecimalField(
-        max_digits=7,
-        decimal_places=2,
-        error_messages={
-            "invalid": "Please provide a valid price number between 0 and $17,500.",
-        },
-    )
+    # price = serializers.DecimalField(
+    #     max_digits=7,
+    #     decimal_places=2,
+    #     error_messages={
+    #         "invalid": "Please provide a valid price number between 0 and $17,500.",
+    #     },
+    # )
 
     class Meta:
         model = Product
@@ -46,13 +46,6 @@ class ProductSerializer(serializers.ModelSerializer):
         if value > 17500:
             raise serializers.ValidationError("Price cannot exceed $17,500")
         return value
-    
-    # currently doing for all requests.. should just be on retrieve.
-    # this is causing the all products view to break.
-    # Could we just have different serializers for different methods?
-    # For example, a ProductRetrieveSerializer(ProductSerializer)? profile.py uses multiple serializers.
-    # Then, add the is_liked serializer method field to just that child serializer?
-
 
 
 class ProductDetailSerializer(ProductSerializer):
@@ -417,7 +410,6 @@ class Products(ViewSet):
         
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-
     @action(methods=["get"], detail=False)
     def liked(self, request):
         current_user = Customer.objects.get(user=request.auth.user)
@@ -433,4 +425,3 @@ class Products(ViewSet):
                 return HttpResponseServerError(ex)
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
-    

--- a/bangazonapi/views/productlike.py
+++ b/bangazonapi/views/productlike.py
@@ -1,0 +1,45 @@
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from bangazonapi.models import ProductLike
+from rest_framework import status
+from .product import ProductSerializer
+from .profile import CustomerSerializer
+
+
+
+
+class ProductLikeSerializer(serializers.ModelSerializer):
+    customer = CustomerSerializer()
+    product = ProductSerializer(many=True)
+
+    class Meta:
+        model = ProductLike
+        fields = ('id', 'product', 'customer')
+
+# class ProductLikes(ViewSet):
+
+#     permission_classes = (IsAuthenticatedOrReadOnly,)
+
+#     def create(self, request):
+
+#         new_product_like = ProductLike()
+#         new_product_like = request.data["product"]
+#         new_product_like.save()
+
+#         serializer = ProductLikeSerializer(new_product_like, context={'request': request})
+
+#         return Response(serializer.data, status=status.HTTP_201_CREATED)
+    
+#     def list(self, request):
+#         product_like = ProductLike.objects.all()
+
+
+#         serializer = ProductLikeSerializer(
+#             product_like, many=True, context={'request': request})
+#         return Response(serializer.data)
+    
+#     # def destroy(self, request, pk=None):
+#     #     product_like = ProductLike.
+    

--- a/seed_data.sh
+++ b/seed_data.sh
@@ -13,4 +13,5 @@ python3 manage.py loaddata productrating
 python3 manage.py loaddata payment
 python3 manage.py loaddata order
 python3 manage.py loaddata order_product
+python3 manage.py loaddata productlikes
 python3 manage.py loaddata favoritesellers

--- a/tests/order.py
+++ b/tests/order.py
@@ -1,6 +1,7 @@
 import json
 from rest_framework import status
 from rest_framework.test import APITestCase
+import datetime
 
 
 class OrderTests(APITestCase):
@@ -80,5 +81,50 @@ class OrderTests(APITestCase):
         self.assertEqual(len(json_response["lineitems"]), 0)
 
     # TODO: Complete order by adding payment type
+
+    def test_complete_order_by_adding_payment_type(self):
+
+        # Add product to order"
+        self.test_add_product_to_order()
+
+        #Add payment method to profile:
+        url="/paymenttypes"
+        data = {'merchant_name':"American Depress",
+                'account_number':123456,
+                'expiration_date':"2026-01-15",
+                "create_date": datetime.date.today()} 
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.post(url, data, format='json')
+
+        # Verify payment was added
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        #Add payment type do order
+        url = "/orders/1"
+        data = {
+        "payment_type": 1
+        }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.put(url, data, format='json')
+        
+        # Verify the order was completed successfully
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Get cart and verify payment type was added
+        url = "/orders/1"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(json_response["id"], 1)
+
+
+        
+
+
+
+
+
 
     # TODO: New line item is not added to closed order


### PR DESCRIPTION
##What and Why
Expanded order test suite functions by adding integration testing for adding payment types to complete order and verification that when an order is completed and a new lineitem is added, it is added to a new order rather than the closed order.

##How
This PR adds two integration tests in the tests/order.py module to verify:

1. Ticket #15 – Complete order by adding payment type:
	•	A payment type is created during test setup.
	•	A PUT request updates an order with the payment type’s ID.
	•	A subsequent GET request confirms that the order has the new payment type assigned.
2. Ticket #16 – New line item is not added to closed order:
        •	Two orders are created for the same customer: one closed and one open.
	•	A product is added to the user’s cart using the standard endpoint.
	•	The test verifies that the new line item is added to the open order only and does not affect the closed order.

## Testing
NOTE: Since we are using poetry, you have to use `poetry run` prior to the python code. 

First, go to the project directory in your terminal.

To run the full test suite:
`poetry run python manage.py test tests -v 1`



## Related Issues
- Completes ticket #15, #16