### PR TITLE
Test/deletepaymenttype

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -17,13 +17,13 @@ from rest_framework.parsers import MultiPartParser, FormParser
 class ProductSerializer(serializers.ModelSerializer):
     """JSON serializer for products"""
 
-    price = serializers.DecimalField(
-        max_digits=7,
-        decimal_places=2,
-        error_messages={
-            "invalid": "Please provide a valid price number between 0 and $17,500.",
-        },
-    )
+    # price = serializers.DecimalField(
+    #     # max_digits=7,
+    #     # decimal_places=2,
+    #     # error_messages={
+    #     #     "invalid": "Please provide a valid price number between 0 and $17,500.",
+    #     # },
+    # )
 
     class Meta:
         model = Product

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -40,4 +40,81 @@ class PaymentTests(APITestCase):
         self.assertEqual(json_response["expiration_date"], "2024-12-31")
         self.assertEqual(json_response["create_date"], str(datetime.date.today()))
 
-    # TODO: Delete payment type
+    def test_delete_payment_type(self):
+        """
+        Ensure we can remove a paymenttype from an order.
+        """
+    
+
+
+        url = "/paymenttypes"
+        creation_data = {
+            "merchant_name": "American Express",
+            "account_number": "111-1111-1111",
+            "expiration_date": "2024-12-31",
+            "create_date": datetime.date.today()
+    }
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, creation_data, format='json')
+        json_response = json.loads(response.content)
+
+        paymenttype_id = json_response["id"]
+
+        url = "/paymenttypes"
+        data = {"paymenttype_id": paymenttype_id}
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.delete(url, data, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        url = "/paymenttypes"
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+        response = self.client.get(url, None, format='json')
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+        self.assertEqual(json_response["merchant_name"], 0)
+        self.assertEqual(json_response["account_number"], 0)
+        self.assertEqual(json_response["expiration_date"], 0)
+        self.assertEqual(json_response["create_date"], 0)
+        # self.assertEqual(json_response["deleted"], 0)
+        # self.assertEqual(json_response["deleted_by_cascade"], 0)
+        # self.assertEqual(json_response["customer_id"], 0)
+
+
+
+        
+
+        
+        
+# def test_delete_payment_type(self):
+#     """
+#     Ensure we can delete a payment type.
+#     """
+#     # First create a payment type
+#     url = "/paymenttypes"
+#     data = {
+#         "merchant_name": "American Express",
+#         "account_number": "111-1111-1111",
+#         "expiration_date": "2024-12-31",
+#         "create_date": datetime.date.today()
+#     }
+#     self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+#     response = self.client.post(url, data, format='json')
+#     json_response = json.loads(response.content)
+    
+#     # Get the ID of the created payment type
+#     payment_type_id = json_response["id"]
+    
+#     # Delete the specific payment type
+#     url = f"/paymenttypes/{payment_type_id}"
+#     response = self.client.delete(url)
+    
+#     # Check that the deletion was successful
+#     self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+    
+#     # Verify the payment type is gone by trying to get it
+#     response = self.client.get(url)
+#     self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/tests/payments.py
+++ b/tests/payments.py
@@ -44,77 +44,30 @@ class PaymentTests(APITestCase):
         """
         Ensure we can remove a paymenttype from an order.
         """
-    
+        # add paymenttype
+        self.test_create_payment_type()
 
 
-        url = "/paymenttypes"
-        creation_data = {
-            "merchant_name": "American Express",
-            "account_number": "111-1111-1111",
-            "expiration_date": "2024-12-31",
-            "create_date": datetime.date.today()
-    }
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-        response = self.client.delete(url, creation_data, format='json')
-        json_response = json.loads(response.content)
-
-        paymenttype_id = json_response["id"]
-
-        url = "/paymenttypes"
-        data = {"paymenttype_id": paymenttype_id}
+        #remove paymenttype
+        url = "/paymenttypes/1"
+        data = {"id": 1 }
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.delete(url, data, format='json')
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
+        # get paymenttype and verify paymenttype was removed 
         url = "/paymenttypes"
         self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
         response = self.client.get(url, None, format='json')
         json_response = json.loads(response.content)
 
+
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(json_response), 0)
+        # self.assertEqual(json_response["merchant_name"], 0)
+        # self.assertEqual(json_response["account_number"], 0)
+        # self.assertEqual(json_response["expiration_date"], 0)
+        # self.assertEqual(json_response["create_date"], 0)
 
-
-        self.assertEqual(json_response["merchant_name"], 0)
-        self.assertEqual(json_response["account_number"], 0)
-        self.assertEqual(json_response["expiration_date"], 0)
-        self.assertEqual(json_response["create_date"], 0)
-        # self.assertEqual(json_response["deleted"], 0)
-        # self.assertEqual(json_response["deleted_by_cascade"], 0)
-        # self.assertEqual(json_response["customer_id"], 0)
-
-
-
-        
-
-        
-        
-# def test_delete_payment_type(self):
-#     """
-#     Ensure we can delete a payment type.
-#     """
-#     # First create a payment type
-#     url = "/paymenttypes"
-#     data = {
-#         "merchant_name": "American Express",
-#         "account_number": "111-1111-1111",
-#         "expiration_date": "2024-12-31",
-#         "create_date": datetime.date.today()
-#     }
-#     self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
-#     response = self.client.post(url, data, format='json')
-#     json_response = json.loads(response.content)
-    
-#     # Get the ID of the created payment type
-#     payment_type_id = json_response["id"]
-    
-#     # Delete the specific payment type
-#     url = f"/paymenttypes/{payment_type_id}"
-#     response = self.client.delete(url)
-    
-#     # Check that the deletion was successful
-#     self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-    
-#     # Verify the payment type is gone by trying to get it
-#     response = self.client.get(url)
-#     self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
## What and Why?
Added a test to ensure paymenttypes can be added and deleted. This update improves test coverage and verifies the backend's paymenttype delete functionality.

## How
Created a new test_paymenttype_delete integration test method in paymenttype in tests/paymenttype.py:

-This method first creates a test product.

-It sends a post request to the url /paymenttype/1 to add a paymenttype.
-It includes the authorization token credentials.
-It verifies that paymenttypes can be added and deleted successfully.

## Testing
-Go to the project directory in your terminal.
-Run the following code:

poetry run python3 manage.py test tests -v 1
Related Issues
Completes ticket #17