### PR TITLE
added owner_name field to stores serializer

### DIFF
--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -11,7 +11,8 @@ from .product import ProductSerializer
 class StoreSerializer(serializers.ModelSerializer):
     store_products = serializers.SerializerMethodField()
     size = serializers.SerializerMethodField()
-    
+    name_of_owner = serializers.SerializerMethodField()
+
     class Meta:
         model = Store
         fields = (
@@ -20,7 +21,8 @@ class StoreSerializer(serializers.ModelSerializer):
             "description",
             "owner",
             "size",
-            "store_products"
+            "store_products",
+            "name_of_owner"
         )
         depth = 1
 
@@ -31,6 +33,15 @@ class StoreSerializer(serializers.ModelSerializer):
     def get_size(self, obj):
         count_of_products = obj.owner.products.count()
         return count_of_products
+    
+    def get_name_of_owner(self, obj):
+        user = obj.owner.user
+        first_name = user.first_name if user.first_name else ""
+        last_name = user.last_name if user.last_name else ""
+        if first_name == "" and last_name == "":
+            return user.username
+        
+        return f"{first_name} {last_name}".strip()
 
 class Stores(ViewSet):
 


### PR DESCRIPTION
Add store owner's name to Store serializer

## Changes

- Added `name_of_owner` field to the StoreSerializer
- Implemented `get_name_of_owner` method to retrieve the owner's full name
- Added logic to fallback to username if first_name and last_name are empty

## Requests / Responses

**Response**

GET `/stores` Returns all stores with owner names

```json
[
  {
        "id": 5,
        "name": "John",
        "description": "ddddd",
        "owner": {
            "id": 8,
            "phone_number": "55555555",
            "address": "123 dog street",
            "user": 9
        },
        "size": 1,
        "store_products": [
            {
                "id": 150,
                "name": "John",
                "price": 1000.0,
                "number_sold": 0,
                "description": "dddddd",
                "quantity": 9,
                "created_date": "2025-04-09",
                "location": "ddd",
                "image_path": null,
                "average_rating": 0
            }
        ],
        "name_of_owner": ""
    }
]
```

## Testing

 -Run the server and make a GET request to /stores endpoint
 -Verify that the name_of_owner field appears in the response
 -Test with users that have both first/last names set
 -Test with users that have only username set (no first/last name
 
 feature tix
 #34