### PR TITLE
successfully have all products under 999 to render

### DIFF
--- a/bangazon/settings.py
+++ b/bangazon/settings.py
@@ -78,7 +78,7 @@ ROOT_URLCONF = 'bangazon.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
+        'DIRS': ["templates"],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [

--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -18,7 +18,7 @@ router.register(r"cart", Cart, "cart")
 router.register(r"paymenttypes", Payments, "payment")
 router.register(r"profile", Profile, "profile")
 router.register(r"stores", Stores, "store" )
-
+router.register(r"reports", Reports, "report")
  
 # Wire up our API using automatic URL routing.
 # Additionally, we include login URLs for the browsable API.

--- a/bangazonapi/views/__init__.py
+++ b/bangazonapi/views/__init__.py
@@ -11,3 +11,4 @@ from .customer import Customers
 from .user import Users
 from .productlike import ProductLike
 from .store import Stores
+from .report import Reports

--- a/bangazonapi/views/report.py
+++ b/bangazonapi/views/report.py
@@ -1,0 +1,39 @@
+from django.shortcuts import render
+from bangazonapi.models import Order
+from bangazonapi.models import Product
+from rest_framework.viewsets import ViewSet
+from rest_framework.decorators import action
+
+
+class Reports(ViewSet):
+    @action(methods=["get"], detail=False)
+    def orders(self, request):
+        status = self.request.query_params.get("status")
+
+        if status == "incomplete":
+            # get all the orders where the payment_type has not been added
+            orders = Order.objects.filter(payment_type__isnull=True)
+
+            # Iterate through the orders, summing the cost of each item and adding it to a total_cost field
+            for order in orders:
+                order.total_cost = 0
+                for line_item in order.lineitems.all():
+                    order.total_cost += line_item.product.price
+
+            # Create context to pass to the Template
+            context = {"orders": orders, "report_title": "Incomplete Orders Report"}
+
+            return render(request, "reports/incomplete_orders.html", context)
+
+    @action(methods=["get"], detail=False) 
+    def inexpensiveproducts(self, request):
+      
+        products = Product.objects.filter(price__lte=999)
+
+      
+        context = {
+            "products": products,
+            "report_title": "Products Under $999"
+        }
+
+        return render(request, "reports/inexpensive_products.html", context)

--- a/templates/reports/inexpensive_products.html
+++ b/templates/reports/inexpensive_products.html
@@ -2,7 +2,7 @@
 <html>
   <body>
 
-    <h1>{{ inexpensive products }}</h1>
+    <h1>{{ report_title }}</h1>
     
     <table class="table">
       <thead>

--- a/templates/reports/inexpensive_products.html
+++ b/templates/reports/inexpensive_products.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <body>
+
+    <h1>{{ inexpensive products }}</h1>
+    
+    <table class="table">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Name</th>
+          <th>Description</th>
+          <th>Price</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for product in products %}
+        <tr>
+          <td>{{ product.id }}</td>
+          <td>{{ product.name }}</td>
+          <td>{{ product.description }}</td>
+          <td>${{ product.price }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </body>
+
+
+</html>


### PR DESCRIPTION
# Add Inexpensive Products Report Feature

This PR adds a new report feature that displays products priced below $999. The report is accessible through a dedicated API endpoint and renders the results as an HTML table.

## Changes

- Added a new decorator in the reports view to filter products priced under $999
- Created a new templates folder with HTML template for rendering the report
- Added new API endpoint `/reports/inexpensiveproducts` to access the report
- Implemented HTML table formatting to display product ID, name, description, and price

## Requests / Responses

**Request**

GET `/reports/inexpensiveproducts` Retrieves a report of all products priced under $999

**Response**

HTTP/1.1 200 OK
Content-Type: text/html

```<!DOCTYPE html>
<html>

<body>

    <h1></h1>

    <table class="table">
        <thead>
            <tr>
                <th>ID</th>
                <th>Name</th>
                <th>Description</th>
                <th>Price</th>
            </tr>
        </thead>
        <tbody>

            <tr>
                <td>2</td>
                <td>Golf</td>
                <td>1994 Volkswagen</td>
                <td>$653.59</td>
            </tr>
```

## Testing

To test this feature:

- [ ] Use Postman to access the endpoint `http://localhost:8000/reports/inexpensiveproducts`
- [ ] Verify that only products with prices less than $999 appear in the report
- [ ] Check that the HTML table correctly displays ID, name, description, and price for each product

## Related Issues

- Fixes #23