### PR TITLE
Bugfix: Product Detail View Not Displaying # of Reviews or Likes

### DIFF
--- a/bangazonapi/models/productlike.py
+++ b/bangazonapi/models/productlike.py
@@ -1,6 +1,11 @@
-from  django.db import models
+from django.db import models
 from .customer import Customer
 
+
 class ProductLike(models.Model):
-    customer = models.ForeignKey(Customer, on_delete=models.CASCADE, related_name="liked_products")
-    product = models.ForeignKey("Product", on_delete=models.CASCADE, related_name="product_likes")
+    customer = models.ForeignKey(
+        Customer, on_delete=models.CASCADE, related_name="liked_products"
+    )
+    product = models.ForeignKey(
+        "Product", on_delete=models.CASCADE, related_name="likes"
+    )

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -9,7 +9,13 @@ from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers
 from rest_framework import status
-from bangazonapi.models import Product, Customer, ProductCategory, ProductLike, ProductRating
+from bangazonapi.models import (
+    Product,
+    Customer,
+    ProductCategory,
+    ProductLike,
+    ProductRating,
+)
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.parsers import MultiPartParser, FormParser
 from django.contrib.auth.models import User
@@ -45,7 +51,7 @@ class ProductDetailSerializer(ProductSerializer):
     is_liked = serializers.SerializerMethodField()
 
     class Meta(ProductSerializer.Meta):
-        fields = ProductSerializer.Meta.fields + ("is_liked",)
+        fields = ProductSerializer.Meta.fields + ("is_liked", "ratings", "likes")
 
     def get_is_liked(self, obj):
         # Get current request
@@ -128,13 +134,6 @@ class Products(ViewSet):
             }
         """
 
-
-
-
-
-
-
-        
         data = request.data.copy()
         data["image_path"] = None
 
@@ -377,7 +376,7 @@ class Products(ViewSet):
         if request.method == "POST":
             rec = Recommendation()
             rec.recommender = Customer.objects.get(user=request.auth.user)
-            the_user=User.objects.get(username=request.data["username"])
+            the_user = User.objects.get(username=request.data["username"])
             rec.customer = Customer.objects.get(user_id=the_user.id)
             rec.product = Product.objects.get(pk=pk)
 
@@ -422,7 +421,6 @@ class Products(ViewSet):
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-
     @action(methods=["get"], detail=False)
     def liked(self, request):
         current_user = Customer.objects.get(user=request.auth.user)
@@ -441,8 +439,7 @@ class Products(ViewSet):
                 return HttpResponseServerError(ex)
 
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
-    
-    
+
     @action(methods=["post"], detail=True)
     def rate_product(self, request, pk=None):
         current_user = Customer.objects.get(user=request.auth.user)
@@ -452,12 +449,21 @@ class Products(ViewSet):
             rating_value = request.data["rating"]
 
             try:
-                product_rating = ProductRating.objects.get(customer=current_user, product=product_instance)
+                product_rating = ProductRating.objects.get(
+                    customer=current_user, product=product_instance
+                )
                 product_rating.rating = rating_value
                 product_rating.save()
-                return Response({"message": "Rating updated successfully"}, status=status.HTTP_200_OK)
+                return Response(
+                    {"message": "Rating updated successfully"},
+                    status=status.HTTP_200_OK,
+                )
             except ProductRating.DoesNotExist:
-                ProductRating.objects.create(customer=current_user, product=product_instance, rating=rating_value)
-                return Response({"message": "Rating added successfully"}, status=status.HTTP_201_CREATED)
+                ProductRating.objects.create(
+                    customer=current_user, product=product_instance, rating=rating_value
+                )
+                return Response(
+                    {"message": "Rating added successfully"},
+                    status=status.HTTP_201_CREATED,
+                )
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
-

--- a/seed_data.sh
+++ b/seed_data.sh
@@ -14,5 +14,5 @@ python3 manage.py loaddata payment
 python3 manage.py loaddata order
 python3 manage.py loaddata order_product
 python3 manage.py loaddata productlikes
-python3 manage.py loaddata favoritesellers
 python3 manage.py loaddata stores
+python3 manage.py loaddata favoritesellers


### PR DESCRIPTION
# Overview 

Product Display View was not properly displaying the number of likes or ratings. This was do to these fields not being included in the ProductDetailSerializer

## Changes

- Changed the related_field name in the ProductLikes model for the product field to 'likes', matching to client-side expectations
- Added 'ratings' and 'likes' fields to the ProductDetailSerializer so that the proper information can get to the client-side.

## Requests / Responses


**Request**
GET `/products/id` 

**Response**

HTTP/1.1 200 OK

```json
{
    "id": 149,
    "name": "Level",
    "price": 5.68,
    "number_sold": 0,
    "description": "A 24-inch level for ensuring straight lines and level surfaces",
    "quantity": 6,
    "created_date": "2023-03-14",
    "location": "Workshop",
    "image_path": "http://localhost:8000/media/products/tools.png",
    "average_rating": 5.0,
    "is_liked": true,
    "ratings": [
        {
            "id": 5,
            "rating": 5,
            "product": 149,
            "customer": 4
        }
    ],
    "likes": [
        {
            "id": 17,
            "customer": 4,
            "product": 149
        }
    ]
}
```

## Related Issues
- Ticket #54 corrects a missing useState import that is required by this bug fix.

## Testing: 
Testing in the browser:
- Ensure you are using the branch related to solving ticket #54.
- Go to a Product Detail View by clicking on a product title in the products list view.
- Like the product. Did the Likes update?
- Make sure you haven't reviewed the product yet. Then, review the product. 
- Did the reviews update?

Testing in Postman or Yaak:
- GET request to `http://localhost:8000/products/id`
- Response should return a 200 OK and the Response Body should include Ratings and Likes fields.