### PR TITLE
report for expensive products completed

### DIFF
--- a/bangazonapi/views/reports.py
+++ b/bangazonapi/views/reports.py
@@ -46,4 +46,17 @@ class Reports(ViewSet):
             "report_title": "Products Under $999"
         }
 
-        return render(request, "reports/inexpensive_products.html", context)
+        return render(request, "reports/products.html", context)
+
+    @action(methods=["get"], detail=False) 
+    def expensiveproducts(self, request):
+        
+            products = Product.objects.filter(price__gt=999)
+
+        
+            context = {
+                "products": products,
+                "report_title": "Products Over $999"
+            }
+
+            return render(request, "reports/products.html", context)

--- a/templates/reports/products.html
+++ b/templates/reports/products.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{{ report_title }}</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+        h1 {
+            color: #333;
+            border-bottom: 1px solid #ccc;
+            padding-bottom: 10px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        th, td {
+            padding: 10px;
+            border: 1px solid #ddd;
+            text-align: left;
+        }
+        th {
+            background-color: #f2f2f2;
+        }
+        tr:nth-child(even) {
+            background-color: #f9f9f9;
+        }
+        .no-products {
+            color: #666;
+            font-style: italic;
+            margin-top: 20px;
+        }
+    </style>
+</head>
+<body>
+    <h1>{{ report_title }}</h1>
+    
+    {% if products %}
+        <table>
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th>Price</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for product in products %}
+                <tr>
+                    <td>{{ product.id }}</td>
+                    <td>{{ product.name }}</td>
+                    <td>{{ product.description }}</td>
+                    <td>${{ product.price|floatformat:2 }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p class="no-products">No products found.</p>
+    {% endif %}
+    
+    <p>Report generated on: {% now "F j, Y H:i" %}</p>
+</body>
+</html>


### PR DESCRIPTION
# Add Expensive Products Report Feature

This PR adds a new report feature that displays products priced above $999. The report is accessible through a dedicated API endpoint and renders the results as an HTML table.

## Changes

- Added a new decorator in the reports view to filter products priced above $999
- Renamed template from inexpensive_products.html to products.html so it could be used for both(inexpensive and expensive products) decorators, added styling to template.
- Added new API endpoint `/reports/expensiveproducts` to access the report


## Requests / Responses

**Request**

GET `[/reports/inexpensiveproducts](http://localhost:8000/reports/expensiveproducts` Retrieves a report of all products priced over $999

**Response**

HTTP/1.1 200 OK
<html>
<body>
    <h1>Products Over $999</h1>
        <table>
            <thead>
                <tr>
                    <th>ID</th>
                    <th>Name</th>
                    <th>Description</th>
                    <th>Price</th>
                </tr>
            </thead>
            <tbody> 
                <tr>
                    <td>1</td>
                    <td>Optima</td>
                    <td>2008 Kia</td>
                    <td>$1655.15</td>
                </tr>
<!--EndFragment-->
</body>
</html>

## Testing

To test this feature:

- [x] Use Postman or browser to access the endpoint `http://localhost:8000/reports/expensiveproducts`
- [x] Verify that only products with prices higher than $999 appear in the report
- [x] Check that the HTML table correctly displays ID, name, description, and price for each product

## Related Issues

- Fixes #22