### PR TITLE
Added logic to check for existing Favorites before creating a new ins…

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -326,12 +326,18 @@ class Profile(ViewSet):
         
         if request.method == "POST":
             store_liked = Store.objects.get(pk=request.data["store_id"])
-            fav_seller = Favorite()
-            fav_seller.customer = customer
-            fav_seller.store = store_liked
 
-            fav_seller.save()
-            return Response(None, status=status.HTTP_201_CREATED)
+            try:
+                if Favorite.objects.filter(customer=customer, store=store_liked).exists():
+                    return Response({"message": "This store has already been liked by user."}, status=status.HTTP_409_CONFLICT)
+            
+            except Favorite.DoesNotExist:    
+                fav_seller = Favorite()
+                fav_seller.customer = customer
+                fav_seller.store = store_liked
+
+                fav_seller.save()
+                return Response(None, status=status.HTTP_201_CREATED)
         
 
 

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -338,6 +338,9 @@ class Profile(ViewSet):
 
                 fav_seller.save()
                 return Response(None, status=status.HTTP_201_CREATED)
+            
+            return Response({}, status=status.HTTP_400_BAD_REQUEST)
+
         
 
 


### PR DESCRIPTION
## Overview:
Added logic to API to check if a favorites instance for a specific user and store already exists before creating a new instance. This change also includes error messaging and a 409 Conflict status. 

## Changes:
Added a try except block that first looks to see if an instance of a favorite already exists before creating a new one. If an instance does exist, additional messaging is sent in the API response stating that the user has already created a favorite for this store along with an HTTP Status of 409 Conflict.

## Requests/ Responses:
Request:

POST ```/profile/favoritesellers``` when a user has already liked a store.

Response:
HTTP 409 CONFLICT
``` 
  {"message": "This store has already been liked by user."}
```

##Testing:

- [x] Open Postman or Yaak and create a POST request to ```/profile/favoritesellers```
- [x] Add an Authorization Token to the headers for the user with a customer_id of 7
- [x] In the body of the request pass in ```{"store_id":1}```
- [x] Verify that you receive the 409 Conflict Status

