### PR TITLE
Bugfix: New Product Form's Errors

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -139,8 +139,17 @@ class Products(ViewSet):
 
         serializer = ProductSerializer(data=data, context={"request": request})
 
+        # Check for serializer or category errors:
+        errors = {}
         if not serializer.is_valid():
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+            errors = serializer.errors.copy()
+
+        # Add category error if needed:
+        if "category_id" in data and data["category_id"] == "0":
+            errors["category"] = ["Select a category"]
+
+        if errors:
+            return Response(errors, status=status.HTTP_400_BAD_REQUEST)
 
         new_product = Product()
         new_product.name = request.data["name"]
@@ -427,9 +436,7 @@ class Products(ViewSet):
 
         if request.method == "GET":
             try:
-                liked_products = Product.objects.filter(
-                    likes__customer=current_user
-                )
+                liked_products = Product.objects.filter(likes__customer=current_user)
                 json_likes = ProductSerializer(
                     liked_products, many=True, context={"request": request}
                 )


### PR DESCRIPTION
# Overview: 
This PR fixes redundancy in the New Product Form's Errors where the unselected category error was appearing in a separate error modal from the fields' error modal. 

This bug was due all fields, other than categories, using serializer validation. Categories is using a try...except... block for error handling.

This bug has been fixed.

# How
- Creating a general errors variable to collect errors.
- Adding serializer errors to the error variable
- Then adding category errors to the error variable
- If the error variable contains data, return a 400 Bad Request response with a list of errors.
- If no error exists, continue on creating the new product object.

# Testing
- In the browser, create a store or go to your existing store.
- Select add a new product from the NavBar's drop down menu.
- Without filling out the form, click save. You should receive the following message:
![Screenshot 2025-04-11 at 10 23 31](https://github.com/user-attachments/assets/87ef0585-8dfa-4b59-bd95-8a14855b85a8)
- close the modal
- Fill out all categories except Category.
- Hit save, you should receive an error modal with the category error.
- close the modal
- select a category
- hit save
- You should be taken to the product detail view for the new product.