### PR TITLE
Added Authentication to Reports

### DIFF
--- a/bangazonapi/views/reports.py
+++ b/bangazonapi/views/reports.py
@@ -3,9 +3,16 @@ from django.contrib.auth.models import User
 from bangazonapi.models import Order, Product, Favorite, Store
 from rest_framework.viewsets import ViewSet
 from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.authentication import TokenAuthentication
 
 class Reports(ViewSet):
-    
+    #In this approach, I decided to add the use TokenAuthentication and IsAuthenticated from the DRF, 
+    # and then add authentication_classes and permission_classes to the ViewSet.
+    #This should require all report endpoints to require a valid auth token.
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
     @action(methods=["get"],detail=False)
     def favoritesellers(self,request):
         #Get the customer_id to find the user information and create the report title variable

--- a/bangazonapi/views/reports.py
+++ b/bangazonapi/views/reports.py
@@ -4,13 +4,13 @@ from bangazonapi.models import Order, Product, Favorite, Store
 from rest_framework.viewsets import ViewSet
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticated
-from rest_framework.authentication import TokenAuthentication
+from rest_framework.authentication import SessionAuthentication, TokenAuthentication
 
 class Reports(ViewSet):
     #In this approach, I decided to add the use TokenAuthentication and IsAuthenticated from the DRF, 
     # and then add authentication_classes and permission_classes to the ViewSet.
     #This should require all report endpoints to require a valid auth token.
-    authentication_classes = [TokenAuthentication]
+    authentication_classes = [SessionAuthentication, TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
     @action(methods=["get"],detail=False)


### PR DESCRIPTION
**Overview**
Adds token-based authentication to the Reports ViewSet to ensure all report endpoints are accessible, but only to authenticated users. This enhances security by protecting sensitive business report data such as customer names, order totals, and payment types.

**How**

- Imported TokenAuthentication and IsAuthenticated from rest_framework.
- Added authentication_classes and permission_classes to the Reports ViewSet.
- All report endpoints now require a valid authentication token to access.
- Unauthenticated requests will receive a 401 Unauthorized response.

**Testing**

- Start the API server.
- Try accessing a report URL (e.g., http://localhost:8000/reports/orders?status=complete) [or any other reports endpoint] without an authentication token → Should return 401 Unauthorized.
- Log in via Postman or Yaak, and attach a valid token in the header:
- With the token, the report should load normally.

Related Issue
Fixed #74 BUG: Add Authentication to Reports