### PR TITLE
fixed key error on store details sold products

### DIFF
--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -43,7 +43,8 @@ class StoreSerializer(serializers.ModelSerializer):
         sold_products = []
 
         for product in all_products:
-            sold_products.append(product.product)
+            if product.product not in sold_products:
+                sold_products.append(product.product)
 
         return ProductSerializer(sold_products, many=True).data
 


### PR DESCRIPTION
# Fixed key error in Store Details view for Sold Products

## Changes

- Added a check to see if a product is already in the "sold_products" list so that the same product doesn't get added twice

## Requests / Responses

**GET Request**

GET ``` http://localhost:8000/stores/1 ```

**GET Response**
HTTP/1.1 200 Ok

```
{
    "id": 1,
    "name": "Tech Treasures",
    "description": "Latest gadgets and tech accessories for all your electronic needs.",
    "owner": {
        "id": 4,
        "phone_number": "555-1212",
        "address": "100 Infinity Way",
        "user": 5
    },
    "size": 59,
    "store_products": [
       ...
    ],
    "sold_products": [
        {
            "id": 50,
            "name": "Golf",
            "price": 653.59,
            "number_sold": 2,
            "description": "1994 Volkswagen",
            "quantity": 4,
            "created_date": "2019-07-10",
            "location": "Berlin",
            "image_path": "/media/products/vehicle.png",
            "average_rating": 3.25
        }
    ],
    "name_of_owner": "Steve Brownlee"
}
```

## Testing

 - [x] Reseed the database by running ``` poetry run ./seed_data.sh ``` in your terminal
 - [x] Using Postman do a GET request to ``` http://localhost:8000/stores/1 ``` and collapse the "store_products" list because it will be really long, so you can then see the "sold_products" list
 - [x] Verify that there are no repeated id fields inside the "sold_products" list
 - [x] On the client side, login as any user, navigate to ` http://localhost:3000/stores/1 ` and verify that not errors are thrown in the console

## Related Issues

Fixes #77